### PR TITLE
Fix "Aw, Snap!" error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const terrain_tiles = {};
 for (var x = -1; x <= 1; x ++){
     for (var y = -1; y <= 1; y ++){
         let key = `${x}, ${y}`;
-        terrain_tiles[key] = new TerrainTile(regl, x, y);
+        terrain_tiles[key] = new TerrainTile(x, y);
     }
 }
 
@@ -48,7 +48,7 @@ img.onload = ()=> {
 
         for(var key in terrain_tiles){
             const tile = terrain_tiles[key];
-            // TerrainTile.drawMesh({ grass, projection_matrix, view_matrix , norms:tile.norms, plane: tile.plane });
+            TerrainTile.drawMesh({ grass, projection_matrix, view_matrix , norms:tile.norms, plane: tile.plane });
         }
     }
 


### PR DESCRIPTION
So it looks like we were still passing regl into the constructor when it should've been `(tile_x, tile_y)`.

This meant that the positions array was full of strings from doing `p[0] = p[0] + regl`, which triggers a browser crash at some point between creating the regl buffer and uploading the data to the GPU :sweat_smile: 

![Screenshot from 2021-12-21 21-20-17](https://user-images.githubusercontent.com/569817/146916271-7b5160bd-df39-441b-8bc8-b74db6d9c964.png)
