### PR TITLE
Fix compatibility with rollup for boids module

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "boids": "^2.0.0",
     "cannon": "^0.6.2",
     "eslint": "^8.2.0",
+    "events": "^3.3.0",
     "gl-matrix": "^3.4.3",
     "gl-wireframe": "^1.0.1",
     "icosphere": "^1.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,10 @@ export default {
     plugins: [
         // node wouldnt be able to run the webgl stuff so we use rollup to compile it
         // nodeResolve makes sure you get the right bits of the right node modules
-        nodeResolve({ mainFields: [ "module", "jsnext:main" ] }),
+        nodeResolve({
+            mainFields: [ "module", "jsnext:main" ],
+            preferBuiltins: false,
+        }),
         commonJS(), // rollup by default only uses ES6 so modlues that use earlier ES's need this to convert it to ES6. makes it backwards compatible
     ],
     onwarn: function (warning, warn) {


### PR DESCRIPTION
boids uses `events`, and since it was built for browserify assumes that the builtin node module is available without installing. We
can fix this by installing the mirror of events on npm, and setting `preferBuiltins: false` on our configuration for plugin-node-resolve :)